### PR TITLE
feat: Support Savings Plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-dist/awsri
+dist/*

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,96 @@
+# Add Compute Savings Plans Support for Fargate and EC2
+
+## Summary
+
+This PR introduces support for Compute Savings Plans calculations for both AWS Fargate and EC2 instances. The commands have been reorganized under a new `compute-savings-plans` subcommand structure for better organization and consistency.
+
+## Changes
+
+### New Features
+
+- **Compute Savings Plans Command Structure**: Added a new `compute-savings-plans` command with subcommands:
+  - `compute-savings-plans fargate`: Calculate Savings Plan costs for Fargate workloads
+  - `compute-savings-plans ec2`: Calculate Savings Plan costs for EC2 instances
+
+- **Fargate Savings Plan Support**: 
+  - Calculate hourly commitment, purchase amount, and savings for Fargate tasks
+  - Support for both Linux and ARM architectures
+  - Configurable payment options (no-upfront, partial-upfront, all-upfront)
+  - Handles vCPU and memory pricing separately
+
+- **EC2 Savings Plan Support**:
+  - Calculate hourly commitment, purchase amount, and savings for EC2 instances
+  - Support for all EC2 instance types
+  - Configurable payment options (no-upfront, partial-upfront, all-upfront)
+
+### Improvements
+
+- **Payment Option Format**: Standardized payment options to use lowercase hyphenated format (`no-upfront`, `partial-upfront`, `all-upfront`) for better CLI consistency
+- **Command Name Fix**: Fixed Kong's automatic conversion of `EC2` to `ec-2` by using explicit `name` tag in struct definition
+- **Code Quality**: 
+  - Converted all Japanese comments to English for better maintainability
+  - Updated CSV headers to English for international compatibility
+
+### Technical Details
+
+- Uses AWS Pricing API to fetch on-demand pricing
+- Uses AWS Savings Plans API to fetch Savings Plan rates
+- Handles unit conversions (millicores to vCPU, MB to GB for Fargate)
+- Supports multiple regions and architectures
+- Includes fallback logic when specific payment options are not available
+
+## Usage Examples
+
+### Fargate Savings Plan Calculation
+
+```bash
+awsri compute-savings-plans fargate \
+  --memory-gb-per-hour=4096 \
+  --vcpu-per-hour=2048 \
+  --task-count=10 \
+  --duration=1 \
+  --payment-option=no-upfront \
+  --region=ap-northeast-1
+```
+
+### EC2 Savings Plan Calculation
+
+```bash
+awsri compute-savings-plans ec2 \
+  --instance-type=m5.large \
+  --count=5 \
+  --duration=1 \
+  --payment-option=no-upfront \
+  --region=ap-northeast-1
+```
+
+## Output Format
+
+The commands output CSV format with the following columns:
+- `Hourly commitment`: Required hourly commitment for the Savings Plan
+- `SP/RI Purchase Amount (USD)`: Total purchase amount for the Savings Plan
+- `Current Cost (USD/month)`: Current monthly cost with on-demand pricing
+- `Cost After Purchase (USD/month)`: Monthly cost after applying Savings Plan
+- `Savings Amount`: Amount saved per month
+- `Savings Rate`: Percentage of savings
+
+## Breaking Changes
+
+- The `fargate` and `ec2` commands are now subcommands under `compute-savings-plans`
+  - Old: `awsri fargate ...`
+  - New: `awsri compute-savings-plans fargate ...`
+  - Old: `awsri ec2 ...`
+  - New: `awsri compute-savings-plans ec2 ...`
+
+## Testing
+
+- [x] Verified Fargate Savings Plan calculations
+- [x] Verified EC2 Savings Plan calculations
+- [x] Tested with different payment options
+- [x] Tested with different regions
+- [x] Verified CSV output format
+- [x] Verified help text and command structure
+
+## Related Issues
+
+N/A

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # awsri
 
-## Instalation
+AWS Reserved Instances and Savings Plans cost calculator
+
+## Installation
 
 ```
 % go install github.com/takaishi/awsri/cmd/awsri@${version}
@@ -8,8 +10,10 @@
 
 ## Usage
 
+### RDS Reserved Instances
+
 ```
-% awsri --service=rds --db-instance-class=db.t4g.large --product-description=mysql --multi-az=true 
+% awsri rds --db-instance-class=db.t4g.large --product-description=mysql --multi-az=true
 | Duration (Year) |  Offering Type  | One Time Payment (USD) | Usage Charges (USD, Monthly) |
 |-----------------|-----------------|------------------------|------------------------------|
 |               1 | No Upfront      |                      0 |                          134 |
@@ -18,11 +22,12 @@
 |               3 | No Upfront      | N/A                    | N/A                          |
 |               3 | Partial Upfront |                   1630 |                           45 |
 |               3 | All Upfront     |                   3192 |                            0 |
-
 ```
 
+### ElastiCache Reserved Instances
+
 ```
-# awsri --service=elasticache --db-instance-class=db.t4g.large --product-description=redis
+% awsri elasticache --cache-node-type=cache.t4g.micro --product-description=redis
 | Duration (Year) |  Offering Type  | One Time Payment (USD) | Usage Charges (USD, Monthly) |
 |-----------------|-----------------|------------------------|------------------------------|
 |               1 | No Upfront      |                      0 |                           73 |
@@ -31,4 +36,35 @@
 |               3 | No Upfront      |                      0 |                         1328 |
 |               3 | Partial Upfront |                   2756 |                           76 |
 |               3 | All Upfront     |                  44584 |                            0 |
+```
+
+### Compute Savings Plans
+
+#### Fargate Savings Plan
+
+Calculate Savings Plan costs for AWS Fargate workloads:
+
+```
+% awsri compute-savings-plans fargate \
+  --vcpu-millicores-per-hour=1024 \
+  --memory-mb-per-hour=1024 \
+  --task-count=1 \
+  --architecture=arm \
+  --payment-option=all-upfront
+Hourly commitment,SP/RI Purchase Amount (USD),Current Cost (USD/month),Cost After Purchase (USD/month),Savings Amount,Savings Rate
+0.03369352,291,33,24,9,26
+```
+
+#### EC2 Compute Savings Plan
+
+Calculate Savings Plan costs for EC2 instances:
+
+```
+% awsri compute-savings-plans ec2 \
+  --instance-type r8g.2xlarge \
+  --count 6 \
+  --duration 1 \
+  --payment-option=all-upfront
+Hourly commitment,SP/RI Purchase Amount (USD),Current Cost (USD/month),Cost After Purchase (USD/month),Savings Amount,Savings Rate
+2.37366,20508,2456,1709,747,30
 ```

--- a/cli.go
+++ b/cli.go
@@ -17,6 +17,7 @@ type GlobalOptions struct {
 type CLI struct {
 	RDS         RDSOption         `cmd:"rds" help:"RDS"`
 	Elasticache ElasticacheOption `cmd:"elasticache" help:"ElastiCache"`
+	Fargate     FargateOption     `cmd:"fargate" help:"Fargate Savings Plan"`
 	Total       TotalOption       `cmd:"total" help:"Calculate total cost of multiple RIs"`
 	Generate    GenerateOption    `cmd:"generate" help:"Generate total command arguments from AWS account"`
 	Version     struct{}          `cmd:"version" help:"show version"`
@@ -65,6 +66,9 @@ func Dispatch(ctx context.Context, command string, cli *CLI) error {
 		return cmd.Run(ctx)
 	case "elasticache":
 		cmd := NewElastiCacheCommand(cli.Elasticache)
+		return cmd.Run(ctx)
+	case "fargate":
+		cmd := NewFargateCommand(cli.Fargate)
 		return cmd.Run(ctx)
 	case "total":
 		cmd := NewTotalCommand(cli.Total)

--- a/cli.go
+++ b/cli.go
@@ -42,10 +42,6 @@ type GenerateOption struct {
 
 func RunCLI(ctx context.Context, args []string) error {
 	var cli CLI
-	// KongがEc2をec-2に変換するため、compute-savings-plans ec2をcompute-savings-plans ec-2に変換
-	if len(args) > 1 && args[0] == "compute-savings-plans" && args[1] == "ec2" {
-		args[1] = "ec-2"
-	}
 	parser, err := kong.New(&cli)
 	if err != nil {
 		return fmt.Errorf("error creating CLI parser: %w", err)
@@ -56,8 +52,6 @@ func RunCLI(ctx context.Context, args []string) error {
 		return fmt.Errorf("error parsing CLI: %w", err)
 	}
 	cmd := kctx.Command()
-	// KongがEC2をec-2に変換するため、ec-2をec2に変換
-	cmd = strings.ReplaceAll(cmd, "ec-2", "ec2")
 	if cmd == "version" {
 		fmt.Println(Version)
 		return nil
@@ -85,7 +79,7 @@ func Dispatch(ctx context.Context, command string, cli *CLI) error {
 		case "fargate":
 			cmd := NewFargateCommand(cli.ComputeSavingsPlans.Fargate)
 			return cmd.Run(ctx)
-		case "ec2", "ec-2":
+		case "ec2":
 			cmd := NewEC2Command(cli.ComputeSavingsPlans.Ec2)
 			return cmd.Run(ctx)
 		default:

--- a/compute_savings_plans.go
+++ b/compute_savings_plans.go
@@ -1,0 +1,6 @@
+package awsri
+
+type ComputeSavingsPlansOption struct {
+	Fargate FargateOption `cmd:"fargate" help:"Fargate Savings Plan"`
+	Ec2     EC2Option     `cmd:"ec2" help:"EC2 Compute Savings Plan"`
+}

--- a/compute_savings_plans.go
+++ b/compute_savings_plans.go
@@ -2,5 +2,5 @@ package awsri
 
 type ComputeSavingsPlansOption struct {
 	Fargate FargateOption `cmd:"fargate" help:"Fargate Savings Plan"`
-	Ec2     EC2Option     `cmd:"ec2" help:"EC2 Compute Savings Plan"`
+	Ec2     EC2Option     `cmd:"" name:"ec2" help:"EC2 Compute Savings Plan"`
 }

--- a/ec2.go
+++ b/ec2.go
@@ -389,7 +389,7 @@ func (c *EC2Command) mapRegionToLocation(region string) string {
 func (c *EC2Command) renderCSV(hourlyCommitment, spPurchaseAmount, currentCost, spCost, savingsAmount, savingsRate float64, noHeader bool) {
 	// Output CSV header (only if noHeader is false)
 	if !noHeader {
-		fmt.Println("Hourly commitment,購入するSP/RI (USD),現在のコスト(USD/月),購入後のコスト(USD/月),削減コスト,削減率")
+		fmt.Println("Hourly commitment,SP/RI Purchase Amount (USD),Current Cost (USD/month),Cost After Purchase (USD/month),Savings Amount,Savings Rate")
 	}
 
 	// Output data row

--- a/ec2.go
+++ b/ec2.go
@@ -1,0 +1,409 @@
+package awsri
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	"github.com/aws/aws-sdk-go-v2/service/savingsplans"
+	savingsplansTypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
+)
+
+type EC2Option struct {
+	Region          string `name:"region" default:"ap-northeast-1" help:"AWS region"`
+	InstanceType    string `name:"instance-type" required:"" help:"EC2 instance type (e.g., m5.large)"`
+	Count           int    `name:"count" required:"" help:"Number of instances"`
+	Duration        int    `name:"duration" default:"1" help:"Duration in years (1 or 3)"`
+	PaymentOption   string `name:"payment-option" default:"No Upfront" help:"Payment option (No Upfront, Partial Upfront, All Upfront)"`
+	NoHeader        bool   `name:"no-header" help:"Do not output CSV header"`
+}
+
+type EC2Command struct {
+	opts EC2Option
+}
+
+type EC2Pricing struct {
+	OnDemandPrice float64 // per hour
+	SPPrice       float64 // per hour (Savings Plan)
+}
+
+func NewEC2Command(opts EC2Option) *EC2Command {
+	return &EC2Command{opts: opts}
+}
+
+func (c *EC2Command) Run(ctx context.Context) error {
+	// Pricing APIとSavings Plans APIはus-east-1でのみ利用可能
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
+	if err != nil {
+		return fmt.Errorf("unable to load SDK config: %v", err)
+	}
+
+	// オンデマンド料金を取得
+	onDemandPrice, err := c.getEC2OnDemandPrice(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to get on-demand price: %v", err)
+	}
+
+	// Savings Plan料金を取得
+	spPrice, err := c.getComputeSavingsPlanPrice(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to get Savings Plan price: %v", err)
+	}
+
+	// 1時間あたりのコストを計算
+	// Hourly commitment = インスタンス数 × 1時間あたりのSP料金
+	hourlyCommitment := float64(c.opts.Count) * spPrice
+
+	// 購入するSP/RI (USD) = Hourly commitment × 720時間 × 12ヶ月 × 期間（年）
+	hoursPerMonth := 720.0
+	spPurchaseAmount := hourlyCommitment * hoursPerMonth * 12.0 * float64(c.opts.Duration)
+
+	// 現在のコスト（オンデマンド）
+	currentCostPerMonth := float64(c.opts.Count) * onDemandPrice * hoursPerMonth
+
+	// 購入後のコスト（Savings Plan）
+	spCostPerMonth := float64(c.opts.Count) * spPrice * hoursPerMonth
+
+	// 削減コストと削減率
+	savingsAmount := currentCostPerMonth - spCostPerMonth
+	savingsRate := (savingsAmount / currentCostPerMonth) * 100.0
+
+	// CSV出力
+	c.renderCSV(hourlyCommitment, spPurchaseAmount, currentCostPerMonth, spCostPerMonth, savingsAmount, savingsRate, c.opts.NoHeader)
+
+	return nil
+}
+
+// getEC2OnDemandPrice はPricing APIを使用してEC2のオンデマンド料金を取得します
+func (c *EC2Command) getEC2OnDemandPrice(cfg aws.Config) (float64, error) {
+	svc := pricing.NewFromConfig(cfg)
+	location := c.mapRegionToLocation(c.opts.Region)
+
+	filters := []types.Filter{
+		{
+			Field: aws.String("location"),
+			Value: aws.String(location),
+			Type:  types.FilterTypeTermMatch,
+		},
+		{
+			Field: aws.String("instanceType"),
+			Value: aws.String(c.opts.InstanceType),
+			Type:  types.FilterTypeTermMatch,
+		},
+		{
+			Field: aws.String("operatingSystem"),
+			Value: aws.String("Linux"),
+			Type:  types.FilterTypeTermMatch,
+		},
+		{
+			Field: aws.String("tenancy"),
+			Value: aws.String("Shared"),
+			Type:  types.FilterTypeTermMatch,
+		},
+		{
+			Field: aws.String("preInstalledSw"),
+			Value: aws.String("NA"),
+			Type:  types.FilterTypeTermMatch,
+		},
+	}
+
+	input := &pricing.GetProductsInput{
+		ServiceCode: aws.String("AmazonEC2"),
+		Filters:     filters,
+		MaxResults:  aws.Int32(100),
+	}
+
+	result, err := svc.GetProducts(context.TODO(), input)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get products: %v", err)
+	}
+
+	if len(result.PriceList) == 0 {
+		return 0, fmt.Errorf("no pricing information found for instance type %s in location %s", c.opts.InstanceType, location)
+	}
+
+	// 最初の結果から料金を抽出
+	return c.extractEC2OnDemandPriceFromResult(result.PriceList[0])
+}
+
+// extractEC2OnDemandPriceFromResult はPricing APIのレスポンスからEC2のオンデマンド料金を抽出します
+func (c *EC2Command) extractEC2OnDemandPriceFromResult(priceListEntry string) (float64, error) {
+	var priceData map[string]interface{}
+	err := json.Unmarshal([]byte(priceListEntry), &priceData)
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal price data: %v", err)
+	}
+
+	// OnDemand料金を取得
+	terms, ok := priceData["terms"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("terms not found in pricing data")
+	}
+
+	onDemand, ok := terms["OnDemand"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("OnDemand terms not found")
+	}
+
+	for _, v := range onDemand {
+		termData, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		priceDimensions, ok := termData["priceDimensions"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, pd := range priceDimensions {
+			dimensionData, ok := pd.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			pricePerUnit, ok := dimensionData["pricePerUnit"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			// unitフィールドを確認（秒単位の場合は時間単位に変換）
+			unit, _ := dimensionData["unit"].(string)
+
+			if usdPrice, ok := pricePerUnit["USD"].(string); ok {
+				price, err := strconv.ParseFloat(usdPrice, 64)
+				if err != nil {
+					continue
+				}
+
+				// 単位が秒の場合は時間単位に変換（秒 × 3600 = 時間）
+				if strings.Contains(strings.ToLower(unit), "second") || strings.Contains(strings.ToLower(unit), "sec") {
+					price = price * 3600.0
+				}
+
+				return price, nil // 1時間あたりの料金を返す
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("price not found in pricing data")
+}
+
+// getComputeSavingsPlanPrice はSavings Plans APIを使用してEC2のSavings Plan料金を取得します
+func (c *EC2Command) getComputeSavingsPlanPrice(cfg aws.Config) (float64, error) {
+	svc := savingsplans.NewFromConfig(cfg)
+
+	// 支払いオプションを引数から取得
+	paymentOptionStr := c.opts.PaymentOption
+	if paymentOptionStr == "" {
+		paymentOptionStr = "No Upfront"
+	}
+
+	// 有効な値かチェック
+	validOptions := map[string]bool{
+		"No Upfront":      true,
+		"Partial Upfront": true,
+		"All Upfront":     true,
+	}
+	if !validOptions[paymentOptionStr] {
+		return 0, fmt.Errorf("invalid payment option: %s (must be one of: No Upfront, Partial Upfront, All Upfront)", paymentOptionStr)
+	}
+
+	paymentOption := savingsplansTypes.SavingsPlanPaymentOption(paymentOptionStr)
+
+	// Savings Plans Offering Ratesを取得
+	durationSeconds := int64(c.opts.Duration * 365 * 24 * 60 * 60) // 年数を秒に変換
+
+	input := &savingsplans.DescribeSavingsPlansOfferingRatesInput{
+		SavingsPlanTypes: []savingsplansTypes.SavingsPlanType{
+			savingsplansTypes.SavingsPlanTypeCompute,
+		},
+		Products: []savingsplansTypes.SavingsPlanProductType{
+			savingsplansTypes.SavingsPlanProductTypeEc2,
+		},
+		ServiceCodes: []savingsplansTypes.SavingsPlanRateServiceCode{
+			savingsplansTypes.SavingsPlanRateServiceCode("AmazonEC2"),
+		},
+		SavingsPlanPaymentOptions: []savingsplansTypes.SavingsPlanPaymentOption{
+			paymentOption,
+		},
+		Filters: []savingsplansTypes.SavingsPlanOfferingRateFilterElement{
+			{
+				Name: savingsplansTypes.SavingsPlanRateFilterAttributeRegion,
+				Values: []string{
+					c.opts.Region,
+				},
+			},
+			{
+				Name: savingsplansTypes.SavingsPlanRateFilterAttributeInstanceType,
+				Values: []string{
+					c.opts.InstanceType,
+				},
+			},
+		},
+		MaxResults: 100,
+	}
+
+	result, err := svc.DescribeSavingsPlansOfferingRates(context.TODO(), input)
+	if err != nil {
+		return 0, fmt.Errorf("failed to describe savings plans offering rates: %v", err)
+	}
+
+	if len(result.SearchResults) == 0 {
+		// 指定された支払いオプションで見つからない場合、他のオプションを試す
+		if paymentOptionStr == "No Upfront" {
+			input.SavingsPlanPaymentOptions = []savingsplansTypes.SavingsPlanPaymentOption{
+				savingsplansTypes.SavingsPlanPaymentOptionAllUpfront,
+			}
+			result, err = svc.DescribeSavingsPlansOfferingRates(context.TODO(), input)
+			if err != nil {
+				return 0, fmt.Errorf("failed to describe savings plans offering rates (All Upfront): %v", err)
+			}
+		}
+		if len(result.SearchResults) == 0 {
+			return 0, fmt.Errorf("no savings plans offering rates found for payment option: %s", paymentOptionStr)
+		}
+	}
+
+	// 期間とインスタンスタイプに一致するオファーを探す
+	var matchedRate float64
+	found := false
+
+	for _, offering := range result.SearchResults {
+		// 期間が一致するか確認
+		if offering.SavingsPlanOffering != nil && offering.SavingsPlanOffering.DurationSeconds != durationSeconds {
+			continue
+		}
+
+		// リージョンが一致するか確認
+		regionCode := c.getRegionCodeFromLocation(offering.Properties)
+		if regionCode != "" && regionCode != c.opts.Region {
+			continue
+		}
+
+		// インスタンスタイプが一致するか確認
+		instanceType := c.getInstanceTypeFromProperties(offering.Properties)
+		if instanceType != "" && instanceType != c.opts.InstanceType {
+			continue
+		}
+
+		// Linuxを確認（Windowsを除外）
+		if offering.UsageType != nil {
+			usageType := strings.ToLower(*offering.UsageType)
+			if strings.Contains(usageType, "windows") {
+				continue
+			}
+		}
+
+		// Propertiesからも確認
+		for _, prop := range offering.Properties {
+			if prop.Name != nil && prop.Value != nil {
+				if *prop.Name == "usagetype" {
+					usageType := strings.ToLower(*prop.Value)
+					if strings.Contains(usageType, "windows") {
+						continue
+					}
+				}
+			}
+		}
+
+		// Rateを取得
+		if offering.Rate != nil {
+			rate, err := strconv.ParseFloat(*offering.Rate, 64)
+			if err == nil {
+				matchedRate = rate
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		return 0, fmt.Errorf("Savings Plan price not found for instance type %s with duration %d years", c.opts.InstanceType, c.opts.Duration)
+	}
+
+	return matchedRate, nil
+}
+
+// getRegionCodeFromLocation はPropertiesからリージョンコードを取得します
+func (c *EC2Command) getRegionCodeFromLocation(properties []savingsplansTypes.SavingsPlanOfferingRateProperty) string {
+	for _, prop := range properties {
+		if prop.Name != nil && *prop.Name == "regionCode" && prop.Value != nil {
+			return *prop.Value
+		}
+		if prop.Name != nil && *prop.Name == "location" && prop.Value != nil {
+			// locationからリージョンコードを逆引き
+			return c.mapLocationToRegion(*prop.Value)
+		}
+	}
+	return ""
+}
+
+// getInstanceTypeFromProperties はPropertiesからインスタンスタイプを取得します
+func (c *EC2Command) getInstanceTypeFromProperties(properties []savingsplansTypes.SavingsPlanOfferingRateProperty) string {
+	for _, prop := range properties {
+		if prop.Name != nil && *prop.Name == "instanceType" && prop.Value != nil {
+			return *prop.Value
+		}
+	}
+	return ""
+}
+
+// mapLocationToRegion はlocation名からリージョンコードを取得します
+func (c *EC2Command) mapLocationToRegion(location string) string {
+	locationMap := map[string]string{
+		"Asia Pacific (Tokyo)":     "ap-northeast-1",
+		"US East (N. Virginia)":    "us-east-1",
+		"US West (Oregon)":         "us-west-2",
+		"EU (Ireland)":             "eu-west-1",
+		"Asia Pacific (Singapore)": "ap-southeast-1",
+		"Asia Pacific (Sydney)":    "ap-southeast-2",
+		"EU (Frankfurt)":           "eu-central-1",
+	}
+	if region, ok := locationMap[location]; ok {
+		return region
+	}
+	return ""
+}
+
+func (c *EC2Command) mapRegionToLocation(region string) string {
+	// リージョン名をPricing APIのlocation形式にマッピング
+	locationMap := map[string]string{
+		"ap-northeast-1": "Asia Pacific (Tokyo)",
+		"us-east-1":      "US East (N. Virginia)",
+		"us-west-2":      "US West (Oregon)",
+		"eu-west-1":      "EU (Ireland)",
+		"ap-southeast-1": "Asia Pacific (Singapore)",
+		"ap-southeast-2": "Asia Pacific (Sydney)",
+		"eu-central-1":   "EU (Frankfurt)",
+	}
+	if location, ok := locationMap[region]; ok {
+		return location
+	}
+	// デフォルトはリージョン名をそのまま使用
+	return region
+}
+
+func (c *EC2Command) renderCSV(hourlyCommitment, spPurchaseAmount, currentCost, spCost, savingsAmount, savingsRate float64, noHeader bool) {
+	// CSVヘッダーを出力（noHeaderがfalseの場合のみ）
+	if !noHeader {
+		fmt.Println("Hourly commitment,購入するSP/RI (USD),現在のコスト(USD/月),購入後のコスト(USD/月),削減コスト,削減率")
+	}
+
+	// データ行を出力
+	// hourly commitmentは四捨五入不要、それ以外は小数点以下不要
+	fmt.Printf("%g,%.0f,%.0f,%.0f,%.0f,%.0f\n",
+		hourlyCommitment,
+		spPurchaseAmount,
+		currentCost,
+		spCost,
+		savingsAmount,
+		savingsRate,
+	)
+}

--- a/fargate.go
+++ b/fargate.go
@@ -1,0 +1,615 @@
+package awsri
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	"github.com/aws/aws-sdk-go-v2/service/savingsplans"
+	savingsplansTypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
+)
+
+type FargateOption struct {
+	Region          string  `name:"region" default:"ap-northeast-1" help:"AWS region"`
+	MemoryGBPerHour float64 `required:"" help:"Memory MB per hour (will be converted to GB)"`
+	VCPUPerHour     float64 `required:"" help:"vCPU millicores per hour (will be converted to vCPU)"`
+	TaskCount       int     `required:"" help:"Number of tasks"`
+	Duration        int     `name:"duration" default:"1" help:"Duration in years (1 or 3)"`
+	Architecture    string  `name:"architecture" default:"linux" help:"Architecture (linux or arm)"`
+	PaymentOption   string  `name:"payment-option" default:"No Upfront" help:"Payment option (No Upfront, Partial Upfront, All Upfront)"`
+	NoHeader        bool    `name:"no-header" help:"Do not output CSV header"`
+}
+
+type FargateCommand struct {
+	opts FargateOption
+}
+
+type FargatePricing struct {
+	VCPUOnDemandPrice   float64 // per hour
+	MemoryOnDemandPrice float64 // per GB per hour
+	VCPUSPPrice         float64 // per hour (Savings Plan)
+	MemorySPPrice       float64 // per GB per hour (Savings Plan)
+}
+
+func NewFargateCommand(opts FargateOption) *FargateCommand {
+	return &FargateCommand{opts: opts}
+}
+
+func (c *FargateCommand) Run(ctx context.Context) error {
+	// Pricing APIとSavings Plans APIはus-east-1でのみ利用可能
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
+	if err != nil {
+		return fmt.Errorf("unable to load SDK config: %v", err)
+	}
+
+	// オンデマンド料金を取得
+	onDemandPricing, err := c.getFargateOnDemandPrice(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to get on-demand price: %v", err)
+	}
+
+	// Savings Plan料金を取得
+	spPricing, err := c.getComputeSavingsPlanPrice(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to get Savings Plan price: %v", err)
+	}
+
+	// 入力パラメータの単位を変換
+	// vCPU: millicores単位の可能性があるため、1024で割ってvCPU数に変換
+	// Memory: MB単位の可能性があるため、1024で割ってGBに変換
+	vcpuCount := c.opts.VCPUPerHour / 1024.0
+	memoryGB := c.opts.MemoryGBPerHour / 1024.0
+
+	// 月間コスト計算（720時間/月）
+	// TaskCount × vCPU数 × 720時間 × vCPU単価 + TaskCount × GB数 × 720時間 × GB単価
+	hoursPerMonth := 720.0
+	currentCostPerMonth := float64(c.opts.TaskCount)*vcpuCount*hoursPerMonth*onDemandPricing.VCPUOnDemandPrice +
+		float64(c.opts.TaskCount)*memoryGB*hoursPerMonth*onDemandPricing.MemoryOnDemandPrice
+
+	spCostPerMonth := float64(c.opts.TaskCount)*vcpuCount*hoursPerMonth*spPricing.VCPUSPPrice +
+		float64(c.opts.TaskCount)*memoryGB*hoursPerMonth*spPricing.MemorySPPrice
+
+	// 1時間あたりのコストを計算（Hourly commitment用）
+	hourlySPCost := spCostPerMonth / hoursPerMonth
+
+	// Hourly commitment = Savings Plan適用後の1時間あたりのコスト
+	hourlyCommitment := hourlySPCost
+
+	// 購入するSP/RI (USD) = Hourly commitment × 720時間 × 12ヶ月 × 期間（年）
+	spPurchaseAmount := hourlyCommitment * hoursPerMonth * 12.0 * float64(c.opts.Duration)
+
+	// 削減コストと削減率
+	savingsAmount := currentCostPerMonth - spCostPerMonth
+	savingsRate := (savingsAmount / currentCostPerMonth) * 100.0
+
+	// CSV出力
+	c.renderCSV(hourlyCommitment, spPurchaseAmount, currentCostPerMonth, spCostPerMonth, savingsAmount, savingsRate, c.opts.NoHeader)
+
+	return nil
+}
+
+// getFargateOnDemandPrice はPricing APIを使用してFargateのオンデマンド料金を取得します
+func (c *FargateCommand) getFargateOnDemandPrice(cfg aws.Config) (*FargatePricing, error) {
+	svc := pricing.NewFromConfig(cfg)
+	location := c.mapRegionToLocation(c.opts.Region)
+
+	// アーキテクチャに応じたフィルタを追加
+	processorArchitecture := "x86_64"
+	if c.opts.Architecture == "arm" {
+		processorArchitecture = "ARM"
+	}
+
+	// vCPU料金を取得（cputype=perCPUフィルタとアーキテクチャフィルタを使用）
+	vcpuPrice, err := c.getFargateOnDemandPriceByType(svc, location, "cputype", "perCPU", processorArchitecture)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vCPU price: %v", err)
+	}
+
+	// メモリ料金を取得（memorytype=perGBフィルタとアーキテクチャフィルタを使用）
+	memoryPrice, err := c.getFargateOnDemandPriceByType(svc, location, "memorytype", "perGB", processorArchitecture)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get memory price: %v", err)
+	}
+
+	return &FargatePricing{
+		VCPUOnDemandPrice:   vcpuPrice,
+		MemoryOnDemandPrice: memoryPrice,
+	}, nil
+}
+
+// getFargateOnDemandPriceByType は指定されたフィルタタイプでFargateのオンデマンド料金を取得します
+func (c *FargateCommand) getFargateOnDemandPriceByType(svc *pricing.Client, location, filterType, filterValue, processorArchitecture string) (float64, error) {
+	// まず、アーキテクチャフィルタなしで検索
+	filters := []types.Filter{
+		{
+			Field: aws.String("location"),
+			Value: aws.String(location),
+			Type:  types.FilterTypeTermMatch,
+		},
+		{
+			Field: aws.String(filterType),
+			Value: aws.String(filterValue),
+			Type:  types.FilterTypeTermMatch,
+		},
+	}
+
+	input := &pricing.GetProductsInput{
+		ServiceCode: aws.String("AmazonECS"),
+		Filters:     filters,
+		MaxResults:  aws.Int32(100),
+	}
+
+	result, err := svc.GetProducts(context.TODO(), input)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get products: %v", err)
+	}
+
+	if len(result.PriceList) == 0 {
+		return 0, fmt.Errorf("no pricing information found for %s=%s in location %s", filterType, filterValue, location)
+	}
+
+	// アーキテクチャでフィルタリング
+	// Pricing APIのレスポンスでは、processorArchitecture属性が空の場合があるため、
+	// usagetypeにアーキテクチャ情報が含まれている（例: APN1-Fargate-ARM-vCPU-Hours:perCPU）
+	var matchedPrice string
+
+	for _, priceListEntry := range result.PriceList {
+		var priceData map[string]interface{}
+		if err := json.Unmarshal([]byte(priceListEntry), &priceData); err != nil {
+			continue
+		}
+
+		product, ok := priceData["product"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		attributes, ok := product["attributes"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// 複数の属性名でアーキテクチャを確認
+		arch := ""
+		if val, ok := attributes["processorArchitecture"].(string); ok {
+			arch = val
+		} else if val, ok := attributes["ProcessorArchitecture"].(string); ok {
+			arch = val
+		} else if val, ok := attributes["processor"].(string); ok {
+			arch = val
+		}
+
+		usagetype, _ := attributes["usagetype"].(string)
+
+		// ARMの場合は、usagetypeに"ARM"が含まれているかも確認
+		if processorArchitecture == "ARM" {
+			if strings.Contains(strings.ToUpper(usagetype), "ARM") || arch == "ARM" {
+				matchedPrice = priceListEntry
+				break
+			}
+		} else if arch == processorArchitecture {
+			// x86_64の場合は、ARMを含まないusagetypeを探す
+			if !strings.Contains(strings.ToUpper(usagetype), "ARM") {
+				matchedPrice = priceListEntry
+				break
+			}
+		}
+	}
+
+	if matchedPrice != "" {
+		return c.extractOnDemandPriceFromResult(matchedPrice)
+	}
+
+	// アーキテクチャが一致しない場合、最初の結果を使用（フォールバック）
+	if len(result.PriceList) > 0 {
+		return c.extractOnDemandPriceFromResult(result.PriceList[0])
+	}
+
+	return 0, fmt.Errorf("no pricing information found")
+}
+
+// extractOnDemandPriceFromResult はPricing APIのレスポンスからオンデマンド料金を抽出します
+func (c *FargateCommand) extractOnDemandPriceFromResult(priceListEntry string) (float64, error) {
+	var priceData map[string]interface{}
+	err := json.Unmarshal([]byte(priceListEntry), &priceData)
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal price data: %v", err)
+	}
+
+	// OnDemand料金を取得
+	terms, ok := priceData["terms"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("terms not found in pricing data")
+	}
+
+	onDemand, ok := terms["OnDemand"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("OnDemand terms not found")
+	}
+
+	for _, v := range onDemand {
+		termData, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		priceDimensions, ok := termData["priceDimensions"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, pd := range priceDimensions {
+			dimensionData, ok := pd.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			pricePerUnit, ok := dimensionData["pricePerUnit"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			// unitフィールドを確認（秒単位の場合は時間単位に変換）
+			unit, _ := dimensionData["unit"].(string)
+
+			if usdPrice, ok := pricePerUnit["USD"].(string); ok {
+				price, err := strconv.ParseFloat(usdPrice, 64)
+				if err != nil {
+					continue
+				}
+
+				// 単位が秒の場合は時間単位に変換（秒 × 3600 = 時間）
+				if strings.Contains(strings.ToLower(unit), "second") || strings.Contains(strings.ToLower(unit), "sec") {
+					price = price * 3600.0
+				}
+
+				return price, nil // 1時間あたりの料金を返す
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("price not found in pricing data")
+}
+
+// getComputeSavingsPlanPrice はSavings Plans APIを使用してFargateのSavings Plan料金を取得します
+func (c *FargateCommand) getComputeSavingsPlanPrice(cfg aws.Config) (*FargatePricing, error) {
+	svc := savingsplans.NewFromConfig(cfg)
+
+	// 支払いオプションを引数から取得
+	// 有効な値: "No Upfront", "Partial Upfront", "All Upfront"
+	paymentOptionStr := c.opts.PaymentOption
+	// デフォルト値の設定
+	if paymentOptionStr == "" {
+		paymentOptionStr = "No Upfront"
+	}
+
+	// 有効な値かチェック
+	validOptions := map[string]bool{
+		"No Upfront":      true,
+		"Partial Upfront": true,
+		"All Upfront":     true,
+	}
+	if !validOptions[paymentOptionStr] {
+		return nil, fmt.Errorf("invalid payment option: %s (must be one of: No Upfront, Partial Upfront, All Upfront)", paymentOptionStr)
+	}
+
+	paymentOption := savingsplansTypes.SavingsPlanPaymentOption(paymentOptionStr)
+
+	// Savings Plans Offering Ratesを取得
+	// リージョンフィルタを追加
+	input := &savingsplans.DescribeSavingsPlansOfferingRatesInput{
+		SavingsPlanTypes: []savingsplansTypes.SavingsPlanType{
+			savingsplansTypes.SavingsPlanTypeCompute,
+		},
+		Products: []savingsplansTypes.SavingsPlanProductType{
+			savingsplansTypes.SavingsPlanProductTypeFargate,
+		},
+		ServiceCodes: []savingsplansTypes.SavingsPlanRateServiceCode{
+			savingsplansTypes.SavingsPlanRateServiceCode("AmazonECS"),
+		},
+		SavingsPlanPaymentOptions: []savingsplansTypes.SavingsPlanPaymentOption{
+			paymentOption,
+		},
+		Filters: []savingsplansTypes.SavingsPlanOfferingRateFilterElement{
+			{
+				Name: savingsplansTypes.SavingsPlanRateFilterAttributeRegion,
+				Values: []string{
+					c.opts.Region,
+				},
+			},
+		},
+		MaxResults: 100,
+	}
+
+	result, err := svc.DescribeSavingsPlansOfferingRates(context.TODO(), input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe savings plans offering rates: %v", err)
+	}
+
+	if len(result.SearchResults) == 0 {
+		// 指定された支払いオプションで見つからない場合、他のオプションを試す
+		// No Upfrontで見つからない場合、All Upfrontを試す
+		if paymentOptionStr == "No Upfront" {
+			input.SavingsPlanPaymentOptions = []savingsplansTypes.SavingsPlanPaymentOption{
+				savingsplansTypes.SavingsPlanPaymentOptionAllUpfront,
+			}
+			result, err = svc.DescribeSavingsPlansOfferingRates(context.TODO(), input)
+			if err != nil {
+				return nil, fmt.Errorf("failed to describe savings plans offering rates (All Upfront): %v", err)
+			}
+		}
+		if len(result.SearchResults) == 0 {
+			return nil, fmt.Errorf("no savings plans offering rates found for payment option: %s", paymentOptionStr)
+		}
+	}
+
+	// 期間に応じたオファーをフィルタリング
+	durationSeconds := int64(c.opts.Duration * 365 * 24 * 60 * 60) // 年数を秒に変換
+
+	// アーキテクチャに応じたフィルタリング条件
+	isARM := c.opts.Architecture == "arm"
+
+	var vcpuPrice, memoryPrice float64
+	foundVCPU := false
+	foundMemory := false
+
+	for _, offering := range result.SearchResults {
+		// 期間が一致するか確認
+		if offering.SavingsPlanOffering != nil && offering.SavingsPlanOffering.DurationSeconds != durationSeconds {
+			continue
+		}
+
+		// リージョンが一致するか確認
+		regionCode := c.getRegionCodeFromLocation(offering.Properties)
+		if regionCode != "" && regionCode != c.opts.Region {
+			continue
+		}
+
+		// UsageTypeとRateを確認
+		// まず、offering.UsageTypeを確認
+		if offering.UsageType != nil {
+			usageType := strings.ToLower(*offering.UsageType)
+
+			// Windowsを除外
+			if strings.Contains(usageType, "windows") {
+				continue
+			}
+
+			// アーキテクチャの一致を確認
+			hasARM := strings.Contains(usageType, "arm")
+			if isARM && !hasARM {
+				continue // ARMを指定しているが、ARMを含まないUsageTypeはスキップ
+			}
+			if !isARM && hasARM {
+				continue // Linux x86_64を指定しているが、ARMを含むUsageTypeはスキップ
+			}
+
+			// vCPUまたはMemoryのUsageTypeを判定
+			if strings.Contains(usageType, "vcpu") || strings.Contains(usageType, "cpu") {
+				if offering.Rate != nil && !foundVCPU {
+					rate, err := strconv.ParseFloat(*offering.Rate, 64)
+					if err == nil {
+						vcpuPrice = rate
+						foundVCPU = true
+					}
+				}
+			} else if strings.Contains(usageType, "gb") || strings.Contains(usageType, "memory") {
+				if offering.Rate != nil && !foundMemory {
+					rate, err := strconv.ParseFloat(*offering.Rate, 64)
+					if err == nil {
+						memoryPrice = rate
+						foundMemory = true
+					}
+				}
+			}
+		}
+
+		// PropertiesからもUsageTypeを確認
+		for _, prop := range offering.Properties {
+			if prop.Name != nil && prop.Value != nil {
+				// UsageTypeを確認
+				if *prop.Name == "usagetype" {
+					usageType := strings.ToLower(*prop.Value)
+
+					// Windowsを除外
+					if strings.Contains(usageType, "windows") {
+						continue
+					}
+
+					// アーキテクチャの一致を確認
+					hasARM := strings.Contains(usageType, "arm")
+					if isARM && !hasARM {
+						continue // ARMを指定しているが、ARMを含まないUsageTypeはスキップ
+					}
+					if !isARM && hasARM {
+						continue // Linux x86_64を指定しているが、ARMを含むUsageTypeはスキップ
+					}
+
+					// vCPUまたはMemoryのUsageTypeを判定
+					if strings.Contains(usageType, "vcpu") || strings.Contains(usageType, "cpu") {
+						if offering.Rate != nil && !foundVCPU {
+							rate, err := strconv.ParseFloat(*offering.Rate, 64)
+							if err == nil {
+								vcpuPrice = rate
+								foundVCPU = true
+							}
+						}
+					} else if strings.Contains(usageType, "gb") || strings.Contains(usageType, "memory") {
+						if offering.Rate != nil && !foundMemory {
+							rate, err := strconv.ParseFloat(*offering.Rate, 64)
+							if err == nil {
+								memoryPrice = rate
+								foundMemory = true
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// unitフィールドも確認
+		unit := strings.ToLower(string(offering.Unit))
+		if strings.Contains(unit, "hour") || strings.Contains(unit, "hr") {
+			// これは時間単位の料金
+			if offering.Rate != nil {
+				rate, err := strconv.ParseFloat(*offering.Rate, 64)
+				if err == nil {
+					// UsageTypeで判定できない場合、unitとrateから推測
+					// 通常、vCPUの方がメモリより高い
+					if !foundVCPU && rate > 0.01 {
+						vcpuPrice = rate
+						foundVCPU = true
+					} else if !foundMemory && rate < 0.01 {
+						memoryPrice = rate
+						foundMemory = true
+					}
+				}
+			}
+		}
+	}
+
+	// 見つからない場合、すべての結果を検索して最初のvCPUとMemoryを見つける
+	if !foundVCPU || !foundMemory {
+		for _, offering := range result.SearchResults {
+			if offering.SavingsPlanOffering != nil && offering.SavingsPlanOffering.DurationSeconds != durationSeconds {
+				continue
+			}
+
+			regionCode := c.getRegionCodeFromLocation(offering.Properties)
+			if regionCode != "" && regionCode != c.opts.Region {
+				continue
+			}
+
+			if offering.Rate != nil {
+				rate, err := strconv.ParseFloat(*offering.Rate, 64)
+				if err != nil {
+					continue
+				}
+
+				// UsageTypeで判定
+				if offering.UsageType != nil {
+					usageType := strings.ToLower(*offering.UsageType)
+					if (strings.Contains(usageType, "vcpu") || strings.Contains(usageType, "cpu")) && !foundVCPU {
+						vcpuPrice = rate
+						foundVCPU = true
+					} else if (strings.Contains(usageType, "gb") || strings.Contains(usageType, "memory")) && !foundMemory {
+						memoryPrice = rate
+						foundMemory = true
+					}
+				}
+
+				// PropertiesからもUsageTypeを確認
+				for _, prop := range offering.Properties {
+					if prop.Name != nil && prop.Value != nil {
+						if *prop.Name == "usagetype" {
+							usageType := strings.ToLower(*prop.Value)
+							if (strings.Contains(usageType, "vcpu") || strings.Contains(usageType, "cpu")) && !foundVCPU {
+								vcpuPrice = rate
+								foundVCPU = true
+							} else if (strings.Contains(usageType, "gb") || strings.Contains(usageType, "memory")) && !foundMemory {
+								memoryPrice = rate
+								foundMemory = true
+							}
+						}
+					}
+				}
+
+				// どちらも見つからない場合、rateの値で推測
+				if !foundVCPU && !foundMemory {
+					if rate > 0.01 {
+						vcpuPrice = rate
+						foundVCPU = true
+					} else {
+						memoryPrice = rate
+						foundMemory = true
+					}
+				}
+			}
+		}
+	}
+
+	if !foundVCPU {
+		return nil, fmt.Errorf("vCPU Savings Plan price not found")
+	}
+	if !foundMemory {
+		return nil, fmt.Errorf("memory Savings Plan price not found")
+	}
+
+	return &FargatePricing{
+		VCPUSPPrice:   vcpuPrice,
+		MemorySPPrice: memoryPrice,
+	}, nil
+}
+
+// getRegionCodeFromLocation はPropertiesからリージョンコードを取得します
+func (c *FargateCommand) getRegionCodeFromLocation(properties []savingsplansTypes.SavingsPlanOfferingRateProperty) string {
+	for _, prop := range properties {
+		if prop.Name != nil && *prop.Name == "regionCode" && prop.Value != nil {
+			return *prop.Value
+		}
+		if prop.Name != nil && *prop.Name == "location" && prop.Value != nil {
+			// locationからリージョンコードを逆引き
+			return c.mapLocationToRegion(*prop.Value)
+		}
+	}
+	return ""
+}
+
+// mapLocationToRegion はlocation名からリージョンコードを取得します
+func (c *FargateCommand) mapLocationToRegion(location string) string {
+	locationMap := map[string]string{
+		"Asia Pacific (Tokyo)":     "ap-northeast-1",
+		"US East (N. Virginia)":    "us-east-1",
+		"US West (Oregon)":         "us-west-2",
+		"EU (Ireland)":             "eu-west-1",
+		"Asia Pacific (Singapore)": "ap-southeast-1",
+		"Asia Pacific (Sydney)":    "ap-southeast-2",
+		"EU (Frankfurt)":           "eu-central-1",
+	}
+	if region, ok := locationMap[location]; ok {
+		return region
+	}
+	return ""
+}
+
+func (c *FargateCommand) mapRegionToLocation(region string) string {
+	// リージョン名をPricing APIのlocation形式にマッピング
+	locationMap := map[string]string{
+		"ap-northeast-1": "Asia Pacific (Tokyo)",
+		"us-east-1":      "US East (N. Virginia)",
+		"us-west-2":      "US West (Oregon)",
+		"eu-west-1":      "EU (Ireland)",
+		"ap-southeast-1": "Asia Pacific (Singapore)",
+		"ap-southeast-2": "Asia Pacific (Sydney)",
+		"eu-central-1":   "EU (Frankfurt)",
+	}
+	if location, ok := locationMap[region]; ok {
+		return location
+	}
+	// デフォルトはリージョン名をそのまま使用
+	return region
+}
+
+func (c *FargateCommand) renderCSV(hourlyCommitment, spPurchaseAmount, currentCost, spCost, savingsAmount, savingsRate float64, noHeader bool) {
+	// CSVヘッダーを出力（noHeaderがfalseの場合のみ）
+	if !noHeader {
+		fmt.Println("Hourly commitment,購入するSP/RI (USD),現在のコスト(USD/月),購入後のコスト(USD/月),削減コスト,削減率")
+	}
+
+	// データ行を出力
+	// hourly commitmentは四捨五入不要、それ以外は小数点以下不要
+	fmt.Printf("%g,%.0f,%.0f,%.0f,%.0f,%.0f\n",
+		hourlyCommitment,
+		spPurchaseAmount,
+		currentCost,
+		spCost,
+		savingsAmount,
+		savingsRate,
+	)
+}

--- a/fargate.go
+++ b/fargate.go
@@ -16,14 +16,14 @@ import (
 )
 
 type FargateOption struct {
-	Region          string  `name:"region" default:"ap-northeast-1" help:"AWS region"`
-	MemoryMBPerHour float64 `required:"" help:"Memory MB per hour (will be converted to GB)"`
+	Region                string  `name:"region" default:"ap-northeast-1" help:"AWS region"`
+	MemoryMBPerHour       float64 `required:"" help:"Memory MB per hour (will be converted to GB)"`
 	VCPUMillicoresPerHour float64 `required:"" help:"vCPU millicores per hour (will be converted to vCPU)"`
-	TaskCount       int     `required:"" help:"Number of tasks"`
-	Duration        int     `name:"duration" default:"1" help:"Duration in years (1 or 3)"`
-	Architecture    string  `name:"architecture" default:"x86_64" help:"Architecture (x86_64 or arm)"`
-	PaymentOption   string  `name:"payment-option" default:"no-upfront" help:"Payment option (no-upfront, partial-upfront, all-upfront)"`
-	NoHeader        bool    `name:"no-header" help:"Do not output CSV header"`
+	TaskCount             int     `required:"" help:"Number of tasks"`
+	Duration              int     `name:"duration" default:"1" help:"Duration in years (1 or 3)"`
+	Architecture          string  `name:"architecture" default:"x86_64" help:"Architecture (x86_64 or arm)"`
+	PaymentOption         string  `name:"payment-option" default:"no-upfront" help:"Payment option (no-upfront, partial-upfront, all-upfront)"`
+	NoHeader              bool    `name:"no-header" help:"Do not output CSV header"`
 }
 
 type FargateCommand struct {

--- a/fargate.go
+++ b/fargate.go
@@ -255,21 +255,21 @@ func (c *FargateCommand) extractOnDemandPriceFromResult(priceListEntry string) (
 				continue
 			}
 
-		// Check unit field (convert from seconds to hours if needed)
-		unit, _ := dimensionData["unit"].(string)
+			// Check unit field (convert from seconds to hours if needed)
+			unit, _ := dimensionData["unit"].(string)
 
-		if usdPrice, ok := pricePerUnit["USD"].(string); ok {
-			price, err := strconv.ParseFloat(usdPrice, 64)
-			if err != nil {
-				continue
-			}
+			if usdPrice, ok := pricePerUnit["USD"].(string); ok {
+				price, err := strconv.ParseFloat(usdPrice, 64)
+				if err != nil {
+					continue
+				}
 
-			// Convert from seconds to hours if unit is in seconds (seconds × 3600 = hours)
-			if strings.Contains(strings.ToLower(unit), "second") || strings.Contains(strings.ToLower(unit), "sec") {
-				price = price * 3600.0
-			}
+				// Convert from seconds to hours if unit is in seconds (seconds × 3600 = hours)
+				if strings.Contains(strings.ToLower(unit), "second") || strings.Contains(strings.ToLower(unit), "sec") {
+					price = price * 3600.0
+				}
 
-			return price, nil // Return price per hour
+				return price, nil // Return price per hour
 			}
 		}
 	}
@@ -609,7 +609,7 @@ func (c *FargateCommand) mapRegionToLocation(region string) string {
 func (c *FargateCommand) renderCSV(hourlyCommitment, spPurchaseAmount, currentCost, spCost, savingsAmount, savingsRate float64, noHeader bool) {
 	// Output CSV header (only if noHeader is false)
 	if !noHeader {
-		fmt.Println("Hourly commitment,購入するSP/RI (USD),現在のコスト(USD/月),購入後のコスト(USD/月),削減コスト,削減率")
+		fmt.Println("Hourly commitment,SP/RI Purchase Amount (USD),Current Cost (USD/month),Cost After Purchase (USD/month),Savings Amount,Savings Rate")
 	}
 
 	// Output data row

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/takaishi/awsri
 
-go 1.22
+go 1.23
 
 toolchain go1.23.5
 
 require (
 	github.com/alecthomas/kong v1.8.1
-	github.com/aws/aws-sdk-go-v2 v1.36.2
+	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.34.7
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.17
@@ -17,15 +17,16 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.11 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.33 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.33 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.31.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/aws/aws-sdk-go-v2 v1.36.2 h1:Ub6I4lq/71+tPb/atswvToaLGVMxKZvjYDVOWEExOcU=
 github.com/aws/aws-sdk-go-v2 v1.36.2/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.41.0 h1:tNvqh1s+v0vFYdA1xq0aOJH+Y5cRyZ5upu6roPgPKd4=
+github.com/aws/aws-sdk-go-v2 v1.41.0/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/config v1.26.6 h1:Z/7w9bUqlRI0FFQpetVuFYEsjzE3h7fpU6HuGmfPL/o=
 github.com/aws/aws-sdk-go-v2/config v1.26.6/go.mod h1:uKU6cnDmYCvJ+pxO9S4cWDb2yWWIH5hra+32hVh1MI4=
 github.com/aws/aws-sdk-go-v2/credentials v1.16.16 h1:8q6Rliyv0aUFAVtzaldUEcS+T5gbadPbWdV1WcAddK8=
@@ -14,8 +16,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.11 h1:c5I5iH+DZcH3xOIMlz3/tC
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.11/go.mod h1:cRrYDYAMUohBJUtUnOhydaMHtiK/1NZ0Otc9lIb6O0Y=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.33 h1:knLyPMw3r3JsU8MFHWctE4/e2qWbPaxDYLlohPvnY8c=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.33/go.mod h1:EBp2HQ3f+XCB+5J+IoEbGhoV7CpJbnrsd4asNXmTL0A=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 h1:rgGwPzb82iBYSvHMHXc8h9mRoOUBZIGFgKb9qniaZZc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16/go.mod h1:L/UxsGeKpGoIj6DxfhOWHWQ/kGKcd4I1VncE4++IyKA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.33 h1:K0+Ne08zqti8J9jwENxZ5NoUyBnaFDTu3apwQJWrwwA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.33/go.mod h1:K97stwwzaWzmqxO8yLGHhClbVW1tC6VT1pDLk1pGrq4=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 h1:1jtGzuV7c82xnqOVfx2F0xmJcOw5374L7N6juGW6x6U=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16/go.mod h1:M2E5OQf+XLe+SZGmmpaI2yy+J326aFf6/+54PoxSANc=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.3 h1:n3GDfwqF2tzEkXlv5cuy4iy7LpKDtqDMcNLfZDu9rls=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.3/go.mod h1:6fQQgfuGmw8Al/3M2IgIllycxV7ZW7WCdVSqfBeUiCY=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.34.7 h1:hwtXl8SdL8pjEeFLc4Ix2cds8VePvjHgdZsLhycmMnI=
@@ -28,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/service/pricing v1.32.17 h1:EtZFyL/uhaXlHjIwHW0KSJv
 github.com/aws/aws-sdk-go-v2/service/pricing v1.32.17/go.mod h1:l7bufyRvU+8mY0Z1BNWbWvjr59dlj9YrLKmeiz5CJ30=
 github.com/aws/aws-sdk-go-v2/service/rds v1.68.0 h1:qvpl0PIyXHVxz53Aw7kdeObSUQ2gpSuqIburDyh0N8w=
 github.com/aws/aws-sdk-go-v2/service/rds v1.68.0/go.mod h1:N/ijzTwR4cOG2P8Kvos/QOCetpDTtconhvDOheqnrTw=
+github.com/aws/aws-sdk-go-v2/service/savingsplans v1.31.1 h1:Zqz+yK0iuS84I6cQExTXewD2/XjH/m+RsCYbhQukbp0=
+github.com/aws/aws-sdk-go-v2/service/savingsplans v1.31.1/go.mod h1:A/FYlteWmWYAAUgFEPEd+zMhZPeusOpFyBxxlUesmuU=
 github.com/aws/aws-sdk-go-v2/service/sso v1.18.7 h1:eajuO3nykDPdYicLlP3AGgOyVN3MOlFmZv7WGTuJPow=
 github.com/aws/aws-sdk-go-v2/service/sso v1.18.7/go.mod h1:+mJNDdF+qiUlNKNC3fxn74WWNN+sOiGOEImje+3ScPM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 h1:QPMJf+Jw8E1l7zqhZmMlFw6w1NmfkfiSK8mS4zOx3BA=
@@ -36,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 h1:NzO4Vrau795RkUdSHKEwiR01FaGz
 github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZAwdfkGMgDY+DVfa61uLe4U=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
+github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=

--- a/pricing_utils.go
+++ b/pricing_utils.go
@@ -1,0 +1,185 @@
+package awsri
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	savingsplansTypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
+)
+
+// mapLocationToRegion maps location name to region code
+func mapLocationToRegion(location string) string {
+	locationMap := map[string]string{
+		"Asia Pacific (Tokyo)":       "ap-northeast-1",
+		"Asia Pacific (Seoul)":       "ap-northeast-2",
+		"Asia Pacific (Osaka)":       "ap-northeast-3",
+		"Asia Pacific (Mumbai)":      "ap-south-1",
+		"Asia Pacific (Singapore)":   "ap-southeast-1",
+		"Asia Pacific (Sydney)":      "ap-southeast-2",
+		"Asia Pacific (Jakarta)":     "ap-southeast-3",
+		"Asia Pacific (Melbourne)":   "ap-southeast-4",
+		"Canada (Central)":           "ca-central-1",
+		"EU (Frankfurt)":             "eu-central-1",
+		"EU (Ireland)":               "eu-west-1",
+		"EU (London)":                "eu-west-2",
+		"EU (Paris)":                 "eu-west-3",
+		"EU (Milan)":                 "eu-south-1",
+		"EU (Stockholm)":             "eu-north-1",
+		"EU (Spain)":                 "eu-south-2",
+		"EU (Zurich)":                "eu-central-2",
+		"Middle East (Bahrain)":      "me-south-1",
+		"Middle East (UAE)":          "me-central-1",
+		"South America (São Paulo)":  "sa-east-1",
+		"US East (N. Virginia)":      "us-east-1",
+		"US East (Ohio)":             "us-east-2",
+		"US West (N. California)":   "us-west-1",
+		"US West (Oregon)":           "us-west-2",
+		"Africa (Cape Town)":         "af-south-1",
+		"Asia Pacific (Hong Kong)":   "ap-east-1",
+		"China (Beijing)":            "cn-north-1",
+		"China (Ningxia)":            "cn-northwest-1",
+		"Israel (Tel Aviv)":          "il-central-1",
+	}
+	if region, ok := locationMap[location]; ok {
+		return region
+	}
+	return ""
+}
+
+// mapRegionToLocation maps region code to location name for Pricing API
+func mapRegionToLocation(region string) string {
+	regionMap := map[string]string{
+		"ap-northeast-1": "Asia Pacific (Tokyo)",
+		"ap-northeast-2": "Asia Pacific (Seoul)",
+		"ap-northeast-3": "Asia Pacific (Osaka)",
+		"ap-south-1":     "Asia Pacific (Mumbai)",
+		"ap-southeast-1": "Asia Pacific (Singapore)",
+		"ap-southeast-2": "Asia Pacific (Sydney)",
+		"ap-southeast-3": "Asia Pacific (Jakarta)",
+		"ap-southeast-4": "Asia Pacific (Melbourne)",
+		"ca-central-1":   "Canada (Central)",
+		"eu-central-1":   "EU (Frankfurt)",
+		"eu-west-1":      "EU (Ireland)",
+		"eu-west-2":      "EU (London)",
+		"eu-west-3":      "EU (Paris)",
+		"eu-south-1":     "EU (Milan)",
+		"eu-north-1":     "EU (Stockholm)",
+		"eu-south-2":     "EU (Spain)",
+		"eu-central-2":   "EU (Zurich)",
+		"me-south-1":     "Middle East (Bahrain)",
+		"me-central-1":   "Middle East (UAE)",
+		"sa-east-1":      "South America (São Paulo)",
+		"us-east-1":      "US East (N. Virginia)",
+		"us-east-2":      "US East (Ohio)",
+		"us-west-1":      "US West (N. California)",
+		"us-west-2":      "US West (Oregon)",
+		"af-south-1":     "Africa (Cape Town)",
+		"ap-east-1":      "Asia Pacific (Hong Kong)",
+		"cn-north-1":     "China (Beijing)",
+		"cn-northwest-1": "China (Ningxia)",
+		"il-central-1":   "Israel (Tel Aviv)",
+	}
+	if location, ok := regionMap[region]; ok {
+		return location
+	}
+	// Default: use region name as is
+	return region
+}
+
+// getRegionCodeFromLocation retrieves region code from Properties
+func getRegionCodeFromLocation(properties []savingsplansTypes.SavingsPlanOfferingRateProperty) string {
+	for _, prop := range properties {
+		if prop.Name != nil && *prop.Name == "regionCode" && prop.Value != nil {
+			return *prop.Value
+		}
+		if prop.Name != nil && *prop.Name == "location" && prop.Value != nil {
+			// Reverse lookup region code from location
+			return mapLocationToRegion(*prop.Value)
+		}
+	}
+	return ""
+}
+
+// extractOnDemandPriceFromResult extracts on-demand pricing from Pricing API response
+func extractOnDemandPriceFromResult(priceListEntry string) (float64, error) {
+	var priceData map[string]interface{}
+	err := json.Unmarshal([]byte(priceListEntry), &priceData)
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal price data: %v", err)
+	}
+
+	// Get OnDemand pricing
+	terms, ok := priceData["terms"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("terms not found in pricing data")
+	}
+
+	onDemand, ok := terms["OnDemand"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("OnDemand terms not found")
+	}
+
+	for _, v := range onDemand {
+		termData, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		priceDimensions, ok := termData["priceDimensions"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, pd := range priceDimensions {
+			dimensionData, ok := pd.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			pricePerUnit, ok := dimensionData["pricePerUnit"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			// Check unit field (convert from seconds to hours if needed)
+			unit, _ := dimensionData["unit"].(string)
+
+			if usdPrice, ok := pricePerUnit["USD"].(string); ok {
+				price, err := strconv.ParseFloat(usdPrice, 64)
+				if err != nil {
+					continue
+				}
+
+				// Convert from seconds to hours if unit is in seconds (seconds × 3600 = hours)
+				if strings.Contains(strings.ToLower(unit), "second") || strings.Contains(strings.ToLower(unit), "sec") {
+					price = price * 3600.0
+				}
+
+				return price, nil // Return price per hour
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("price not found in pricing data")
+}
+
+// renderCSV renders CSV output for Savings Plan calculations
+func renderCSV(hourlyCommitment, spPurchaseAmount, currentCost, spCost, savingsAmount, savingsRate float64, noHeader bool) {
+	// Output CSV header (only if noHeader is false)
+	if !noHeader {
+		fmt.Println("Hourly commitment,SP/RI Purchase Amount (USD),Current Cost (USD/month),Cost After Purchase (USD/month),Savings Amount,Savings Rate")
+	}
+
+	// Output data row
+	// hourly commitment doesn't need rounding, others don't need decimal places
+	fmt.Printf("%g,%.0f,%.0f,%.0f,%.0f,%.0f\n",
+		hourlyCommitment,
+		spPurchaseAmount,
+		currentCost,
+		spCost,
+		savingsAmount,
+		savingsRate,
+	)
+}


### PR DESCRIPTION
## Summary

This PR introduces support for Compute Savings Plans calculations for both AWS Fargate and EC2 instances. The commands have been reorganized under a new `compute-savings-plans` subcommand structure for better organization and consistency.

## Changes

### New Features

- **Compute Savings Plans Command Structure**: Added a new `compute-savings-plans` command with subcommands:
  - `compute-savings-plans fargate`: Calculate Savings Plan costs for Fargate workloads
  - `compute-savings-plans ec2`: Calculate Savings Plan costs for EC2 instances

- **Fargate Savings Plan Support**: 
  - Calculate hourly commitment, purchase amount, and savings for Fargate tasks
  - Support for both Linux and ARM architectures
  - Configurable payment options (no-upfront, partial-upfront, all-upfront)
  - Handles vCPU and memory pricing separately

- **EC2 Savings Plan Support**:
  - Calculate hourly commitment, purchase amount, and savings for EC2 instances
  - Support for all EC2 instance types
  - Configurable payment options (no-upfront, partial-upfront, all-upfront)

### Improvements

- **Payment Option Format**: Standardized payment options to use lowercase hyphenated format (`no-upfront`, `partial-upfront`, `all-upfront`) for better CLI consistency
- **Command Name Fix**: Fixed Kong's automatic conversion of `EC2` to `ec-2` by using explicit `name` tag in struct definition
- **Code Quality**: 
  - Converted all Japanese comments to English for better maintainability
  - Updated CSV headers to English for international compatibility

### Technical Details

- Uses AWS Pricing API to fetch on-demand pricing
- Uses AWS Savings Plans API to fetch Savings Plan rates
- Handles unit conversions (millicores to vCPU, MB to GB for Fargate)
- Supports multiple regions and architectures
- Includes fallback logic when specific payment options are not available